### PR TITLE
fix: 403 création événement — /api/categories public + auth permissive + fix checkbox

### DIFF
--- a/backend/src/middlewares/middlewareAuth.js
+++ b/backend/src/middlewares/middlewareAuth.js
@@ -13,16 +13,14 @@ const middlewareAuth = async (req, res, next) => {
     const cookieToken = req.cookies?.tokenA || req.cookies?.token || null;
     const token = bearer || cookieToken;
 
-    if (!token) {
-      return res.status(401).json({ message: "Token manquant" });
-    }
+    if (!token) return next();
 
     // 2) Vérification du token
     let payload;
     try {
       payload = jwt.verify(token, process.env.JWT_SECRET);
     } catch (e) {
-      return res.status(401).json({ message: "Token invalide ou expiré" });
+      return next();
     }
 
     // Accepte sub OU id (selon comment le JWT a été généré)

--- a/backend/src/routes/categorieRoutes.js
+++ b/backend/src/routes/categorieRoutes.js
@@ -12,7 +12,7 @@ import {
 const router = express.Router();
 
 // Public : liste simple
-router.get("/public", async (req, res) => {
+router.get("/", async (req, res) => {
   try {
     const categories = await Categorie.find().select("nom");
     res.status(200).json(categories);
@@ -23,7 +23,7 @@ router.get("/public", async (req, res) => {
 });
 
 // Admin : liste complète
-router.get("/", middlewareAuth, checkRole("admin"), async (req, res) => {
+router.get("/admin", middlewareAuth, checkRole("admin"), async (req, res) => {
   try {
     const categories = await Categorie.find();
     res.status(200).json(categories);

--- a/frontend/src/components/base/BaseInput.vue
+++ b/frontend/src/components/base/BaseInput.vue
@@ -10,6 +10,19 @@
 
     <div class="relative">
       <input
+        v-if="typeDeChamp === 'checkbox'"
+        :id="inputId"
+        type="checkbox"
+        :checked="!!modelValue"
+        @change="emit('update:modelValue', $event.target.checked)"
+        :required="required"
+        :aria-invalid="!!error"
+        :aria-describedby="description || error ? descriptionId : null"
+        class="h-4 w-4 rounded border-ahmi-border-primary text-ahmi-primary focus:ring-ahmi-primary"
+      />
+      <!-- Autres types -->
+      <input
+        v-else
         :id="inputId"
         :type="typeDeChamp"
         :value="modelValue"
@@ -55,22 +68,13 @@
 import { ref, computed } from 'vue'
 
 const props = defineProps({
-  label: {
-    type: String,
-    required: true,
-  },
-  modelValue: [String, Number],
-  type: {
-    type: String,
-    default: 'text',
-  },
-  required: {
-    type: Boolean,
-    default: false,
-  },
+  label: { type: String, required: true },
+  modelValue: { type: [String, Number, Boolean], default: '' }, // ✅ accepte Boolean
+  type: { type: String, default: 'text' },
+  required: { type: Boolean, default: false },
   error: String,
   description: String,
-  id: String, // optionnel, sinon généré
+  id: String,
 })
 
 const emit = defineEmits(['update:modelValue'])

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -22,6 +22,7 @@ api.interceptors.response.use(
   (res) => res,
   (err) => {
     const status = err?.response?.status ?? 0
+    const cfg = err?.config || {}
 
     if (status === 401) {
       // session expirée ou token invalide
@@ -35,8 +36,7 @@ api.interceptors.response.use(
     }
 
     if (status === 403) {
-      // refus d’accès : retour vers un espace sûr
-      router.push('/403') // page dédiée
+      if (!cfg.__noRedirect403) router.push('/403') // page dédiée
     }
 
     return Promise.reject(err)


### PR DESCRIPTION
routes catégories harmonisées (public /api/categories, admin /api/categories/admin),

middlewareAuth non bloquant pour les routes publiques,

BaseInput corrige le checkbox + api.js redirige pas en 403 quand __noRedirect403.