### PR TITLE
feat(events): l’admin peut ouvrir et valider un évènement en_attente

### DIFF
--- a/backend/src/controllers/eventController.js
+++ b/backend/src/controllers/eventController.js
@@ -7,6 +7,15 @@ class EventController {
   constructor() {
     this.eventService = EventService;
   }
+  // Helper: détecte correctement un admin, qu’il soit dans `role` ou dans `roles[]`
+  isAdminUser = (req) => {
+    const r = req?.utilisateur?.role;
+    const rs = req?.utilisateur?.roles;
+    const hasRole = typeof r === "string" && r.toLowerCase() === "admin";
+    const hasInArray =
+      Array.isArray(rs) && rs.some((x) => String(x).toLowerCase() === "admin");
+    return hasRole || hasInArray;
+  };
 
   // Créer un événement (partner ou admin)
   createEvent = async (req, res) => {
@@ -34,8 +43,7 @@ class EventController {
 
       console.info("Utilisateur courant dans getAllEvents :", req.utilisateur);
 
-      const filter =
-        req.utilisateur?.role === "admin" ? {} : { statut: "approuve" };
+      const filter = this.isAdminUser(req) ? {} : { statut: "approuve" };
       console.info(" Filtre utilisé pour getAllEvents :", filter);
 
       const events = await this.eventService.getAllEvents(filter);
@@ -54,7 +62,7 @@ class EventController {
       if (!event)
         return res.status(404).json({ message: "Évènement introuvable" });
       const user = req.utilisateur; // undefined si pas d'auth
-      const isAdmin = user?.role === "admin";
+      const isAdmin = this.isAdminUser(req);
       const creatorId =
         event?.createur?._id?.toString?.() ?? event?.createur?.toString?.();
       const isCreator = user && creatorId === user.id;
@@ -86,7 +94,7 @@ class EventController {
       const creatorId =
         existing?.createur?._id?.toString?.() ??
         existing?.createur?.toString?.();
-      const isAdmin = req.utilisateur?.role === "admin";
+      const isAdmin = this.isAdminUser(req);
       if (creatorId !== req.utilisateur.id && !isAdmin) {
         return res.status(403).json({ message: "Accès refusé" });
       }
@@ -154,7 +162,7 @@ class EventController {
       if (!event)
         return res.status(404).json({ message: "Évènement introuvable" });
       const user = req.utilisateur; // peut être undefined si route publique
-      const isAdmin = user?.role === "admin";
+      const isAdmin = this.isAdminUser(req);
       const creatorId =
         event?.createur?._id?.toString?.() ?? event?.createur?.toString?.();
       const isCreator = user && creatorId === user.id;

--- a/backend/src/routes/eventRoutes.js
+++ b/backend/src/routes/eventRoutes.js
@@ -56,7 +56,7 @@ router.get("/mine", middlewareAuth, (req, res) =>
 );
 router.get(
   "/:id",
-
+  middlewareAuth,
   validateObjectId,
   eventController.getEventById
 );

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -3,10 +3,13 @@ import axios from 'axios'
 import router from '@/router'
 
 const apiBaseURL =
-  import.meta.env.VITE_API_URL || import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000/api'
+  import.meta.env.VITE_API_URL ||
+  import.meta.env.VITE_API_BASE_URL ||
+  import.meta.env.VITE_BACKEND_URL ||
+  'http://localhost:5000/api'
 const api = axios.create({
   baseURL: apiBaseURL,
-  withCredentials: true, // si tu utilises cookies httpOnly
+  withCredentials: true, //  cookies httpOnly
   timeout: 10000,
 })
 

--- a/frontend/src/services/eventService.js
+++ b/frontend/src/services/eventService.js
@@ -13,11 +13,11 @@ export const updateEvent = (id, data, config = {}) => api.put(`/events/${id}`, d
 export const getPlacesRestantes = (id, config = {}) =>
   api.get(`/events/${id}/places-restantes`, config)
 
-export const getEventsByStatus = (status, config = {}) =>
-  api.get(`/events/statut/${status}`, config)
+export const getEventsByStatus = (statut, config = {}) =>
+  api.get(`/events/statut/${statut}`, config)
 
 export const updateEventStatus = (id, status, config = {}) =>
-  api.patch(`/events/${id}`, { statut: status }, config)
+  api.patch(`/events/${id}/statut`, { statut: status }, config)
 
 export const deleteEvent = (id, config = {}) => api.delete(`/events/${id}`, config)
 

--- a/frontend/src/utils/date.js
+++ b/frontend/src/utils/date.js
@@ -1,11 +1,57 @@
 // src/utils/date.js
-export const formatDateForInput = (date) => {
-  const d = new Date(date)
-  const offset = d.getTimezoneOffset()
-  const localDate = new Date(d.getTime() - offset * 60000)
-  return localDate.toISOString().slice(0, 16)
+import { format as dfFormat, isValid, parseISO } from 'date-fns'
+
+// Détecte "YYYY-MM-DDTHH:mm" (format attendu par <input type="datetime-local">, sans timezone)
+const RE_INPUT_LOCAL = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/
+
+// Convertit diverses entrées en Date valide OU null (NE JETTE PAS)
+function coerceToDate(value) {
+  if (!value) return null
+
+  // Déjà une Date ?
+  if (value instanceof Date) return isValid(value) ? value : null
+
+  // "YYYY-MM-DDTHH:mm" => interprétation locale
+  if (typeof value === 'string' && RE_INPUT_LOCAL.test(value)) {
+    const [datePart, timePart] = value.split('T')
+    const [y, m, d] = datePart.split('-').map(Number)
+    const [H, M] = timePart.split(':').map(Number)
+    const local = new Date(y, m - 1, d, H, M, 0, 0)
+    return isValid(local) ? local : null
+  }
+
+  // ISO complète ? (parseISO ne jette pas, renvoie Invalid Date si échec)
+  if (typeof value === 'string') {
+    const iso = parseISO(value)
+    if (isValid(iso)) return iso
+  }
+
+  // Ultime tentative
+  const d = new Date(value)
+  return isValid(d) ? d : null
 }
 
-export const toISOStringFromInput = (localDateStr) => {
-  return new Date(localDateStr).toISOString()
+/**
+ * formatDateForInput
+ * Transforme une date (Date | string) en "yyyy-MM-dd'T'HH:mm" pour <input type="datetime-local">.
+ * Retourne '' si invalide / absente (pas d’exception).
+ */
+export function formatDateForInput(value) {
+  const d = coerceToDate(value)
+  if (!d) return ''
+  try {
+    return dfFormat(d, "yyyy-MM-dd'T'HH:mm")
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * toISOStringFromInput
+ * Transforme une valeur venant d’un <input type="datetime-local"> (ou une date quelconque)
+ * en ISO string (UTC) pour l’API. Retourne null si invalide (pas d’exception).
+ */
+export function toISOStringFromInput(value) {
+  const d = coerceToDate(value)
+  return d ? d.toISOString() : null
 }

--- a/frontend/src/views/EventDetailsAdmin.vue
+++ b/frontend/src/views/EventDetailsAdmin.vue
@@ -219,13 +219,17 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import axios from 'axios'
 import { format } from 'date-fns'
 import fr from 'date-fns/locale/fr'
 import { useToast } from 'vue-toastification'
 import BaseButton from '@/components/base/BaseButton.vue'
 import MainLayout from '@/layout/MainLayout.vue'
-import { updateEventStatus, getCategories, updateEvent } from '@/services/eventService'
+import {
+  getEventById,
+  updateEventStatus,
+  getCategories,
+  updateEvent,
+} from '@/services/eventService'
 import { formatDateForInput, toISOStringFromInput } from '@/utils/date'
 import { useEvenementsStore } from '@/stores/evenements'
 
@@ -304,7 +308,7 @@ const sauvegarderModifications = async () => {
       participationFinanciere: Number(evenement.value.participationFinanciere),
       lienSiteInternet: evenement.value.lienSiteInternet?.trim(),
       lienInstagram: evenement.value.lienInstagram?.trim(),
-      categories: evenement.value.categories.map((cat) =>
+      categories: (evenement.value.categories || []).map((cat) =>
         typeof cat === 'string' ? cat : cat._id
       ),
       dateDebut: toISOStringFromInput(dateDebut.value),
@@ -353,15 +357,26 @@ onMounted(async () => {
   try {
     const catRes = await getCategories()
     allCategories.value = catRes.data.data || catRes.data
-    const res = await axios.get(`${import.meta.env.VITE_BACKEND_URL}/api/events/${route.params.id}`)
-    evenement.value = res.data.data || res.data
+    const id = route.params?.id
+    if (!id) {
+      error.value = 'ID manquant'
+      return
+    }
+    const res = await getEventById(id, { __noRedirect403: true })
+    const ev = res.data?.data || res.data
+
+    // ⚠️ v-model sur <select multiple> → tableau d’IDs requis
+    const cats = Array.isArray(ev?.categories)
+      ? ev.categories.map((c) => (typeof c === 'string' ? c : c?._id)).filter(Boolean)
+      : []
+    evenement.value = { ...ev, categories: cats }
 
     adresseRue.value = evenement.value?.lieu?.rue || ''
     codePostal.value = evenement.value?.lieu?.codePostal || ''
     commune.value = evenement.value?.lieu?.commune || ''
 
-    dateDebut.value = formatDateForInput(evenement.value?.dateDebut)
-    dateFin.value = formatDateForInput(evenement.value?.dateFin)
+    dateDebut.value = formatDateForInput(ev?.dateDebut) || ''
+    dateFin.value = formatDateForInput(ev?.dateFin) || ''
   } catch (e) {
     error.value = "Impossible de charger l'événement."
     console.error(e)


### PR DESCRIPTION
- routes: GET /events/:id passe par middlewareAuth (permissif)
- controller: helper isAdminUser + accès admin/créateur sur non-approuvés
- service: PATCH /events/:id/statut (endpoint corrigé), conserve config/signal
- vue admin: chargement via service, catégories -> IDs, préremplissage dates/adresse
- utils: helpers date-fns robustes